### PR TITLE
Added new dependencies & removed erroneous unittest dependency

### DIFF
--- a/docker-compose-py-siblings/Dockerfile
+++ b/docker-compose-py-siblings/Dockerfile
@@ -10,7 +10,7 @@ RUN add-apt-repository ppa:jonathonf/python-3.6 \
     && apt-get update \
     && apt-get install -y python3.6 python3-pip python3.6-dev build-essential libbz2-dev libssl-dev libreadline-dev libsqlite3-dev tk-dev libevent-dev \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10 \
-    && pip install --upgrade pip flask_testing coverage nose pluggy py randomize tox tox-docker pyyaml
+    && pip install --upgrade pip flask_testing coverage nose pluggy py randomize tox tox-docker pyyaml flask-httpauth python-owasp-zap-v2.4
 
 ENV WORKSPACE /home/jenkins
 


### PR DESCRIPTION
1. Unittest is already included in python so attempting to install it via pip was throwing errors.
2. Added new dependencies for running flask-httpauth module and owasp-zap python api