### PR TITLE
chore: Use --no-cache-dir flag to pip in Dockerfiles, to save space

### DIFF
--- a/docker-compose-py-siblings/Dockerfile
+++ b/docker-compose-py-siblings/Dockerfile
@@ -10,7 +10,7 @@ RUN add-apt-repository ppa:jonathonf/python-3.6 \
     && apt-get update \
     && apt-get install -y python3.6 python3-pip python3.6-dev build-essential libbz2-dev libssl-dev libreadline-dev libsqlite3-dev tk-dev libevent-dev \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10 \
-    && pip install --upgrade pip flask_testing coverage nose pluggy py randomize tox tox-docker pyyaml flask-httpauth python-owasp-zap-v2.4
+    && pip install --no-cache-dir --upgrade pip flask_testing coverage nose pluggy py randomize tox tox-docker pyyaml flask-httpauth python-owasp-zap-v2.4
 
 ENV WORKSPACE /home/jenkins
 

--- a/docker-e2e-compose-py/Dockerfile
+++ b/docker-e2e-compose-py/Dockerfile
@@ -20,8 +20,8 @@ RUN add-apt-repository ppa:jonathonf/python-3.6 \
     && apt-get install -y python3.6 python3-pip python3.6-dev build-essential libbz2-dev libssl-dev libreadline-dev libsqlite3-dev tk-dev libevent-dev \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10 
 
-RUN pip install --upgrade pip flask_testing coverage nose pluggy py randomize tox tox-docker pyyaml \
-    && pip install selenium
+RUN pip install --no-cache-dir --upgrade pip flask_testing coverage nose pluggy py randomize tox tox-docker pyyaml \
+    && pip install --no-cache-dir selenium
 
 RUN wget https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip \
     && unzip chromedriver_linux64.zip \


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>